### PR TITLE
Check for TRUE too.

### DIFF
--- a/config.go
+++ b/config.go
@@ -115,7 +115,7 @@ func initConfig() {
 	if cafile := os.Getenv("CAFILE"); cafile != "" {
 		config.CAFile = cafile
 	}
-	if insecureSkipVerify := os.Getenv("SKIPVERIFY"); insecureSkipVerify == "true" || insecureSkipVerify == "1" {
+	if insecureSkipVerify := os.Getenv("SKIPVERIFY"); insecureSkipVerify == "true" || insecureSkipVerify == "1" || insecureSkipVerify == "TRUE" {
 		config.InsecureSkipVerify = true
 	}
 


### PR DESCRIPTION
README states that SKIPVERIFY should be set to "TRUE" to skip validation of SSL certs.  In fact this is untrue, as code only checks for "true" or 1. 

This fixes that, I think?


